### PR TITLE
fixed all-hid tab errors

### DIFF
--- a/config/router.config.js
+++ b/config/router.config.js
@@ -130,7 +130,7 @@ export default [
       {
         name: 'Account',
         icon: 'user',
-        path: '/account/',
+        path: '/account/settings',
         component: './Account/Settings/Info',
         authority: ['admin'],
 

--- a/src/pages/Account/Settings/Info.js
+++ b/src/pages/Account/Settings/Info.js
@@ -111,7 +111,7 @@ class Info extends Component {
           }}
         >
           <div className={styles.leftmenu}>
-            <Menu mode={mode} selectedKeys={[selectKey]} onClick={this.selectKey}>
+            <Menu mode={mode} defaultSelectedKeys={[selectKey]} onClick={this.selectKey}>
               {this.getmenu()}
             </Menu>
           </div>

--- a/src/pages/Candidates/ViewInterviews.js
+++ b/src/pages/Candidates/ViewInterviews.js
@@ -48,8 +48,13 @@ const TableList = () => {
 
   const getColumnSearchProps = useSearch();
 
+  const allTab = '1';
+  const hidTab = '2';
+
+  const tab = allTab;
+
   const [selectedRows, setSelectedRows] = useState([]);
-  const [archives, setArchives] = useState(false);
+  const [archives, setArchives] = useState(tab === hidTab);
   const [editInterview, setEditInterview] = useState(null);
   const [inviteCandidates, setInviteCandidates] = useState(null);
   // const [reload, setReload] = useState(false);
@@ -247,14 +252,18 @@ const TableList = () => {
         }
         footer={
           <Tabs
-            defaultActiveKey="1"
-            onChange={() => {
-              setArchives(flag => !flag);
+            defaultActiveKey={allTab}
+            onChange={tabKey => {
+              if (tabKey === hidTab) {
+                setArchives(true);
+              } else {
+                setArchives(false);
+              }
               setSelectedRows([]);
             }}
           >
-            <Tabs.TabPane tab="Active" key="1" />
-            <Tabs.TabPane tab="Hidden" key="2" />
+            <Tabs.TabPane tab="Active" key={allTab} />
+            <Tabs.TabPane tab="Hidden" key={hidTab} />
           </Tabs>
         }
       />

--- a/src/pages/ShortLists/ShortLists.js
+++ b/src/pages/ShortLists/ShortLists.js
@@ -21,13 +21,18 @@ const openShortListAnalytics = data => {
   router.push(`/sharelinks/analytics/?id=${_id}`);
 };
 
+const allTab = '1';
+const hidTab = '2';
+
+const tab = allTab;
+
 const ShortLists = () => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [loading, setLoading] = useState(true);
   // const [dataSource, setDataSource] = useState([]);
   const [filteredInfo, setFilteredInfo] = useState(null);
 
-  const [archives, setArchives] = useState(false);
+  const [archives, setArchives] = useState(tab === hidTab);
 
   const globalData = useContext(GlobalContext);
   const [filteredData, setFilteredData] = useState(globalData.shareLinks);
@@ -217,14 +222,18 @@ const ShortLists = () => {
         onBack={null}
         footer={
           <Tabs
-            defaultActiveKey="1"
-            onChange={() => {
-              setArchives(flag => !flag);
+            defaultActiveKey={allTab}
+            onChange={tabKey => {
+              if (tabKey === hidTab) {
+                setArchives(true);
+              } else {
+                setArchives(false);
+              }
               setSelectedRows([]);
             }}
           >
-            <Tabs.TabPane tab="All" key="1" />
-            <Tabs.TabPane tab="Hidden" key="2" />
+            <Tabs.TabPane tab="All" key={allTab} />
+            <Tabs.TabPane tab="Hidden" key={hidTab} />
           </Tabs>
         }
       />


### PR DESCRIPTION
# Issues Addressed:

- Identified additional broken all/hid tabs and restructured the onChange handler to correspond correctly to the chosen tab (see #363)
  - Fixed in viewInterviews and shortLists
- The menu in the account settings tab was broken and only highlighting the "Company Branding" tab even when the user changed tabs.
  - The issue was that the `selectedKeys` prop was being used for the `menu` component, which was never updating with the changing state. I changed this prop to the `defaultSelectedKeys` prop which allows for the "Company Branding" tab to be opened by default, but updates each time a new tab is selected so that the current tab is highlighted.
  - [Video](https://www.loom.com/share/b602d9ca450e4c398ce991156cd05e15)

# Testing

- For the broken all/hid tabs I tested using a local server and checking all additional files that use the `tabs` component to ensure the changes did not break anything
- For the menu highlighting error, I tested using a local server (see [Video](https://www.loom.com/share/b602d9ca450e4c398ce991156cd05e15))