### PR TITLE
added scrolling to accounts-users table

### DIFF
--- a/src/pages/Account/Settings/UserSettings.js
+++ b/src/pages/Account/Settings/UserSettings.js
@@ -193,7 +193,7 @@ const Team = () => {
           render(test, data) {
             const { invitedEmail, _id } = data;
             return (
-              <>
+              <Space>
                 <Popconfirm
                   title={`Resend an invite to ${invitedEmail}?`}
                   onConfirm={() => resendInvite(_id, invitedEmail)}
@@ -206,7 +206,6 @@ const Team = () => {
                     </Button>
                   </Tooltip>
                 </Popconfirm>
-
                 <Popconfirm
                   title={`Are you sure you want to delete ${invitedEmail}'s invite?`}
                   onConfirm={() => deleteInvite(_id, invitedEmail)}
@@ -215,12 +214,12 @@ const Team = () => {
                   cancelText="Cancel"
                 >
                   <Tooltip placement="left" title="Delete Invite">
-                    <Button style={{ marginLeft: 5 }} shape="circle">
+                    <Button shape="circle">
                       <DeleteOutlined />
                     </Button>
                   </Tooltip>
                 </Popconfirm>
-              </>
+              </Space>
             );
           },
         }
@@ -318,12 +317,17 @@ const Team = () => {
       >
         <TabPane tab="Current Users" key="1">
           <Spin spinning={!team}>
-            <Table dataSource={team} pagination={false} columns={columnsTeam} />{' '}
+            <Table dataSource={team} pagination={false} columns={columnsTeam} scroll={{ x: 400 }} />{' '}
           </Spin>
         </TabPane>
         <TabPane tab="Invited Users" key="2">
           <Spin spinning={!invites}>
-            <Table dataSource={invites} pagination={false} columns={columnsInvites} />{' '}
+            <Table
+              dataSource={invites}
+              pagination={false}
+              columns={columnsInvites}
+              scroll={{ x: 400 }}
+            />{' '}
           </Spin>
         </TabPane>
       </Tabs>


### PR DESCRIPTION
I added horizontal scrolling to the accounts-users table (for both the current and invited users tabs). Users can now scroll left and right to see all columns on smaller screens.

I also fixed the spacing of the action items in the invited users table.

https://www.loom.com/share/b47501266115495e99fd378888487a54